### PR TITLE
Add initial state change tracker (for subscriptions to any kind of updates)

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -3,6 +3,7 @@ type EventCounter @entity {
   id: ID! # this will have a fixed id of '1' since there will only be one place to count events.
   buyEventCount: BigInt!
   buyEvents: [BuyEvent!]
+  stateChanges: [StateChange]!
   changePriceEventCount: BigInt
 }
 
@@ -75,6 +76,14 @@ type BuyEvent @entity {
   price: Price!
   newOwner: Patron!
   timestamp: BigInt!
+}
+
+# For every transaction, list the changes, and stat
+type StateChange @entity {
+  id: ID! # tx
+  changes: [String!]!
+  patronChanges: [Patron]!
+  wildcardChange: [Wildcard]!
 }
 
 type ChangePriceEvent @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -81,6 +81,7 @@ type BuyEvent @entity {
 # For every transaction, list the changes, and stat
 type StateChange @entity {
   id: ID! # tx
+  timestamp: BigInt!
   changes: [String!]!
   patronChanges: [Patron]!
   wildcardChange: [Wildcard]!

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,6 +1,6 @@
 import { Steward } from "../../generated/Steward/Steward";
 import { Address, BigInt } from "@graphprotocol/graph-ts";
-import { Patron } from "../../generated/schema";
+import { Patron, StateChange } from "../../generated/schema";
 import { log } from "@graphprotocol/graph-ts";
 import { ZERO_ADDRESS } from "../CONSTANTS";
 
@@ -80,4 +80,19 @@ export function updateAvailableDepositAndForeclosureTime(
   );
   patron.lastUpdated = currentTimestamp;
   patron.save();
+}
+
+// NOTE: it is impossible for this code to return null, the compiler is just retarded!
+export function getOrInitialiseStateChange(txId: string): StateChange | null {
+  let stateChange = StateChange.load(txId);
+
+  if (stateChange == null) {
+    stateChange = new StateChange(txId);
+    stateChange.changes = [];
+    stateChange.patronChanges = [];
+    stateChange.wildcardChange = [];
+    return stateChange;
+  } else {
+    return stateChange;
+  }
 }

--- a/src/v0/steward.ts
+++ b/src/v0/steward.ts
@@ -198,6 +198,7 @@ function createCounterIfDoesntExist(): void {
   eventCounter.buyEventCount = BigInt.fromI32(0);
   eventCounter.changePriceEventCount = BigInt.fromI32(0);
   eventCounter.buyEvents = [];
+  eventCounter.stateChanges = [];
   eventCounter.save();
 }
 function createWildcardIfDoesntExist(

--- a/src/v1/steward.ts
+++ b/src/v1/steward.ts
@@ -156,6 +156,7 @@ export function handleBuy(event: Buy): void {
     patronOld.id,
     patron.id
   ]);
+  stateChange.timestamp = event.block.timestamp;
   stateChange.wildcardChange = stateChange.wildcardChange.concat([wildcard.id]);
   stateChange.save();
 


### PR DESCRIPTION
Basically every event from the same transaction is logged together in a single `StateChange`. This then includes an array of all the events that were triggered, all the patrons that changed, and all the wildcards that changed.

I have made all of these arrays for future flexibility. For the moment, at most a single wildcard(actually a foreclosure is an exception to this, but I haven't coded that yet completely), or two patrons will ever change in a transaction. But in the future we may have different bulk actions possible. No need to rewrite.