### PR TITLE
Small ammendment to totalTimeHeld before moving on.

### DIFF
--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -88,6 +88,9 @@ export function updateAvailableDepositAndForeclosureTime(
       .div(GLOBAL_PATRONAGE_DENOMINATOR)
       .div(NUM_SECONDS_IN_YEAR_BIG_INT)
   );
+  patron.totalTimeHeld = patron.totalTimeHeld.plus(
+    timeSinceLastUpdate.times(BigInt.fromI32(patron.tokens.length))
+  );
   patron.patronTokenCostScaledNumerator = steward.totalPatronOwnedTokenCost(
     patron.address as Address
   );

--- a/src/v0/steward.ts
+++ b/src/v0/steward.ts
@@ -355,11 +355,9 @@ export function handleLogBuy(event: LogBuy): void {
       let patron = Patron.load(ownerString);
       patron.availableDeposit = steward.depositAbleToWithdraw(owner);
 
-      let heldUntil = minBigInt(patron.foreclosureTime, txTimestamp);
-      let timeSinceLastUpdate = heldUntil.minus(patron.lastUpdated);
-      patron.totalTimeHeld = patron.totalTimeHeld.plus(
-        timeSinceLastUpdate.times(BigInt.fromI32(patron.tokens.length))
-      );
+      // This is for Vitalik+Simon, so token didn't foreclose, and he only holds 1 token.
+      let timeSinceLastUpdate = txTimestamp.minus(patron.lastUpdated);
+      patron.totalTimeHeld = patron.totalTimeHeld.plus(timeSinceLastUpdate);
       patron.totalContributed = patron.totalContributed.plus(
         patron.patronTokenCostScaledNumerator
           .times(timeSinceLastUpdate)
@@ -412,6 +410,8 @@ export function handleLogBuy(event: LogBuy): void {
     patron.lastUpdated = txTimestamp;
     patron.foreclosureTime = txTimestamp;
   }
+
+  // Now even if the patron puts in extra deposit when they buy a new token this will foreclose their old tokens.
   let heldUntil = minBigInt(patron.foreclosureTime, txTimestamp);
 
   let timeSinceLastUpdate = heldUntil.minus(patron.lastUpdated);


### PR DESCRIPTION
Not much changed, there are still bugs in this code, just not sure where. We will delay adding leaderboards for 'accumulative time held' and 'total contributed' for patrons until this is working correctly.