### PR TITLE
Make the previously owned tokens array compulsory!

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -103,10 +103,10 @@ type PatronNew @entity {
   # previouslyOwnedTokens: [Wildcard!]!
   tokens: [WildcardNew!]!
   # availableDeposit: BigInt!
-  # patronTokenCostScaledNumerator: BigInt!
+  patronTokenCostScaledNumerator: BigInt!
   # foreclosureTime: BigInt!
   # deposit: BigInt!
-  # totalContributed: BigInt!
+  totalContributed: BigInt!
   totalTimeHeld: BigInt!
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -60,7 +60,7 @@ type Patron @entity {
   id: ID! # Just the address
   address: Bytes! # address
   lastUpdated: BigInt!
-  previouslyOwnedTokens: [Wildcard!]
+  previouslyOwnedTokens: [Wildcard!]!
   tokens: [Wildcard!]!
   availableDeposit: BigInt!
   patronTokenCostScaledNumerator: BigInt!

--- a/src/CONSTANTS.ts
+++ b/src/CONSTANTS.ts
@@ -21,6 +21,11 @@ export const AMOUNT_RAISED_BY_VITALIK_VINTAGE_CONTRACT: BigInt = BigInt.fromI32(
 
 // NOTE: BigInt.fromI32(300000000000) errors since '300000000000' is too big for i32
 //       similarly for the patronage denominator.
+
+// 20 ETH = 20000000000000000000 = 20 * billion * billion
+export const VITALIK_PRICE_WHEN_OWNED_BY_SIMON = BigInt.fromI32(20)
+  .times(BILLION)
+  .times(BILLION);
 export const VITALIK_PATRONAGE_NUMERATOR = BigInt.fromI32(300).times(BILLION);
 export const GLOBAL_PATRONAGE_DENOMINATOR = BigInt.fromI32(1000).times(BILLION);
 export const VITALIK_PATRONAGE_DENOMINATOR = GLOBAL_PATRONAGE_DENOMINATOR;


### PR DESCRIPTION
This is a very simple PR (once again the diff is complicated by the previous one ...)

But, it in the ui if you don't include a `!` on a field from the schema it becomes 'optional'. It is more elegant if it isn't optional but rather returns an empty array.. 