### PR TITLE
fix to `patron.totalContributed` overstatement + refactor

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -39,7 +39,7 @@ type Wildcard @entity {
   priceHistory: [Price!]
   tokenUri: TokenUri!
   totalCollected: BigInt!
-  timeCollected: BigInt!
+  timeCollected: BigInt! # this is the timestamp of the last collection on the wildcard not the total time collected for wildcard 
   auctionStartPrice: BigInt
   launchTime: BigInt!
 }
@@ -76,7 +76,7 @@ type Patron @entity {
   availableDeposit: BigInt! # only updated via depositAbleToWithdraw function
   patronTokenCostScaledNumerator: BigInt!
   effectivePatronTokenCostScaledNumerator: BigInt! # for when deposit = 0 
-  foreclosureTime: BigInt! # time in future when patron will foreclose (run out of deposit)
+  foreclosureTime: BigInt! # timestamp in future when patron will foreclose (run out of deposit), zero if patron doensn't own tokens. 
   # deposit: BigInt!
   totalContributed: BigInt!
   totalTimeHeld: BigInt! # cumulative parallel time for each token (timePassed*patron.tokens.length) 

--- a/src/rewrite/steward.ts
+++ b/src/rewrite/steward.ts
@@ -4,6 +4,7 @@ import { Patron, Wildcard } from "../../generated/schema";
 import { initialiseDefaultPatronIfNull } from "../util";
 import { createWildcardIfDoesntExist } from "../v0/helpers";
 import { ID_PREFIX } from "../CONSTANTS";
+
 export function genericUpdateTimeHeld(
   owner: Address,
   txTimestamp: BigInt,

--- a/src/steward.ts
+++ b/src/steward.ts
@@ -25,9 +25,12 @@ import * as NEW from "./rewrite/steward";
 import { Global } from "../generated/schema";
 import { GLOBAL_ID } from "./CONSTANTS";
 
-// NOTE: Events labled with the latest version of the contracts (eg V1) will be the only events that will be called.
-//       The rest of the events need to be there to make sure that the graph can do a full sync of the history.
-//       Thus this is just an interface file with no logic in it.
+/**
+ * NOTE: Events labled with the latest version of the contracts (eg V1) will be the only events that will be called.
+ * The rest of the events need to be there to make sure that the graph can do a full sync of the history.
+ * Thus this is just an interface file with no logic in it.
+ */
+
 export function handleLogBuy(event: LogBuy): void {
   // log.warning("handle log buy! {}", [event.block.hash.toHexString()]);
   V0.handleLogBuy(event);

--- a/src/v0/steward.ts
+++ b/src/v0/steward.ts
@@ -318,8 +318,8 @@ export function handleLogBuy(event: LogBuy): void {
   } 
 
   patron.foreclosureTime = patronForeclosureTime;
-
   patron.totalContributed = newPatronTotalContributed;
+  
   patron.save();
 
   if (patronOld.id != ID_PREFIX + "NO_OWNER") {


### PR DESCRIPTION
`patron.totalContributed` update in handleBuy changed to use smaller of foreclosureTime and now. 
This should correct any overstatement to patron.totalContributed due to buy handler. 

Also:

- variable name changes to be in line with jason's comment about prepending (WIP)
- removal of redundant `patron.totalContributed` update in handleBuy 
- removal of redundant code in handlePriceChange 

**Reasoning behind NOT needing to add a check when using minBigInt**
 The patron's forecosureTime here won't have been set to zero or changed to reflect this sale yet so it'll always be
 larger than lastUpdated if the patron has tokens and this handler wouldn't have been called if there wasn't a token to sell. 
 So there is no need for a check that timeSinceLastUpdatePatron is only being set to positive values.
